### PR TITLE
issue #9 adding travis script and readme badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: python
+
+python:
+
+  - 2.7
+
+# command to install dependencies
+
+before_install:
+
+  - pip install coveralls
+
+install:
+
+  - "pip install ."
+
+script:
+
+  - coverage run --source=melody -m py.test
+
+  - coverage report -m
+
+after_success:
+
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
+[![Build Status](https://travis-ci.org/rupertford/melody.svg?branch=master)](https://travis-ci.org/rupertford/melody)
+[![Coverage Status](https://coveralls.io/repos/github/rupertford/melody/badge.svg?branch=master)](https://coveralls.io/github/rupertford/melody?branch=master)
+[![Code Health](https://landscape.io/github/rupertford/melody/master/landscape.svg?style=flat)](https://landscape.io/github/rupertford/melody/master)
+
 # melody
 Lightweight python parameter search software for performance analysis and tuning


### PR DESCRIPTION
Added in travis script which run pytest tests and coverage, which is passed onto coveralls. Added badges for travis build success (see if tests pass), coverage information (via coveralls) and code quality (pep8 etc) via landscape. Note, there are no tests at this point so we shouldn't expect much, other than results from landscape.